### PR TITLE
Use stable release for enqueue components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     }
   ],
   "require": {
-    "enqueue/enqueue-bundle": "0.9.x-dev",
+    "enqueue/enqueue-bundle": "^0.9",
     "doctrine/doctrine-bundle": "^1.4",
-    "enqueue/job-queue": "0.9.x-dev"
+    "enqueue/job-queue": "^0.9"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
Hey Guys!

we would really like to use this flex pack. But currently, it requires a nonstable release for enqueue job bundle. 

It would be cool if you could merge them and hopefully tag a stable release.

Fixes #1 

Thanks :heart: 